### PR TITLE
fix search description text

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,10 @@
 -->
 <html lang="en">
   <head>
+    <meta name="description" content="We Vote is building the next generation of voting tech. <br /> 
+                                      We're creating a digital voter guide informed by issues you care about and people you trust. <br />
+                                      Through our nonpartisan, open source platform, we'll help you become a better voter, up and down the ballot.
+                                      />
     <title>We Vote</title>
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />


### PR DESCRIPTION
based on my reading of this page https://support.google.com/gsa/answer/6329200#2ca1bec8-9cb6-4e70-a959-8993bc3d4a61

this should replace the snippet that appears in search results

### What github.com/wevote/WebApp/issues does this fix?
https://github.com/wevote/WebApp/issues/1694

### Changes included this pull request?
added meta-tag with site description taken from about page